### PR TITLE
fix #26 for updating TD error formula for PER in ddqn

### DIFF
--- a/DDQN/ddqn.py
+++ b/DDQN/ddqn.py
@@ -124,7 +124,7 @@ class DDQN:
         if(self.with_per):
             q_val = self.agent.predict(state)
             q_val_t = self.agent.target_predict(new_state)
-            next_best_action = np.argmax(q_val)
+            next_best_action = np.argmax(self.agent.predict(new_state))
             new_val = reward + self.gamma * q_val_t[0, next_best_action]
             td_error = abs(new_val - q_val)[0]
         else:


### PR DESCRIPTION
Fix for the issue #26 with regards to the formula for calculating TD error for PER.

`delta(j) = Reward(j) + gamma(j) * Q_target(S_j, arg max_a Q(S_j, a)) - Q(S_j-1, A_j-1)`

Here, the `Q(S_j, a)` is the Q value predict by the model on the new state and not the old state.


